### PR TITLE
필터 모달이 닫히면 페이지 스크롤 불가능

### DIFF
--- a/src/shared/ui/Modal/Modal.tsx
+++ b/src/shared/ui/Modal/Modal.tsx
@@ -15,10 +15,10 @@ export default function Modal({
   const modalRef = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
-    if (isOpen) {
-      document.body.style.overflow = 'hidden'
-    } else {
-      document.body.style.overflow = 'auto'
+    document.body.style.overflow = isOpen ? 'hidden' : ''
+
+    return () => {
+      document.body.style.overflow = ''
     }
   }, [isOpen])
 


### PR DESCRIPTION
#### 🕶️ Summary (요약)
- 필터 모달이 닫힐때 스타일 제거
<!-- 변경 사항의 전체적인 요약을 작성해주세요. -->

#### ⛈️ Describe your Change (변경사항)
- Modal 컴포넌트 overflow 스타일을 ''로 설정
- cleanup 함수 추가하여 컴포넌트가 언마운트될 때도 스타일 초기화
<!-- 어떤 변경이 이루어졌는지 자세히 설명해주세요. -->

#### ⛅️ Issue number and link (참고)
#34 

